### PR TITLE
Add https to the discord link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AbletonLiveOnLinux
-A Repository for All Things Related to Running Ableton Live on Linux, part of the newly formed [Ableton on Linux Discord Group](discord.gg/yM2Jjh8xYA).
+A Repository for All Things Related to Running Ableton Live on Linux, part of the newly formed [Ableton on Linux Discord Group](https://discord.gg/yM2Jjh8xYA).
 
 # Live 12
 ## Install Documentation (WIP)


### PR DESCRIPTION
Add https to the discord link so github doesn't think it's relative to the repo

Clicking it currently sends me to this:

<img width="740" height="72" alt="image" src="https://github.com/user-attachments/assets/f5a7c8f0-024b-41fe-a952-be3510fefa81" />
